### PR TITLE
Install licenses with new 11.0 license manager

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ branches:
   except:
     - /^v[0-9]/
 
-before_install: openssl aes-256-cbc -K $encrypted_2be821de35a9_key -iv $encrypted_2be821de35a9_iv -in secure/alteryx-devops-chef.pem.enc -out ~/alteryx-devops-chef.pem -d
+before_install: 'if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then openssl aes-256-cbc -K $encrypted_2be821de35a9_key -iv $encrypted_2be821de35a9_iv -in secure/alteryx-devops-chef.pem.enc -out ~/alteryx-devops-chef.pem -d; fi'
 
 install:
   - export COOKBOOK_TAG="v$(grep version metadata.rb | awk '{print $NF}' | sed "s/'//g")"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,11 +1,11 @@
 default['alteryx'] = {}
-default['alteryx']['license'] = {}
+default['alteryx']['license']['key'] = nil
 default['alteryx']['force_secrets_update'] = nil
 default['alteryx']['r_source'] = nil
 default['alteryx']['r_version'] = nil
 default['alteryx']['restart_on_change'] = false
 default['alteryx']['source'] = nil
-default['alteryx']['version'] = '10.6.8.17850'
+default['alteryx']['version'] = '11.0.2.25199'
 default['alteryx']['runtimesettings']['engine']['num_threads'] =
   node['cpu']['total'] + 1
 default['alteryx']['runtimesettings']['engine']['sort_join_memory'] =

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email ''
 license          'Apache 2.0'
 description      'Installs/Configures Alteryx server'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.12.1'
+version          '0.12.2'
 supports         'windows'
 source_url       'https://github.com/alteryx/cookbook-alteryx-server'
 issues_url       'https://github.com/alteryx/cookbook-alteryx-server/issues'

--- a/resources/license.rb
+++ b/resources/license.rb
@@ -1,10 +1,12 @@
 property :license, String, name_property: true, required: true
+property :key, String
 property :email, String
 property :skip, [TrueClass, FalseClass]
 
 default_action :activate
 
 load_current_value do
+  key node['alteryx']['license']['key']
   email node['alteryx']['license']['email'] unless email
   skip node['alteryx']['license']['skip'] if skip.nil?
   skip false if skip.nil?
@@ -15,7 +17,7 @@ def activate_license(type, license_address)
     exe = 'C:\\Program Files\\Alteryx\\bin\\AlteryxActivateLicenseKeyCmd.exe'
     cmd = "\"#{exe}\" #{license} \"#{license_address}\""
   elsif type == 'file'
-    exe = 'C:\\Program Files\\Alteryx\\bin\\bin32\\SrcLicenseManager.exe'
+    exe = 'C:\\Program Files\\Alteryx\\bin\\AlteryxLicenseManager.exe'
     cmd = "\"#{exe}\" /InstallSrcLc \"#{license}\""
   else
     raise 'Invalid license type.'
@@ -25,7 +27,7 @@ def activate_license(type, license_address)
 end
 
 action :activate do
-  lic_type = ::File.exist?(license) ? 'file' : 'key'
+  lic_type = ::File.exist?(key) ? 'file' : 'key'
 
   execute 'Activate License' do
     command activate_license(lic_type, email)

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -37,7 +37,7 @@ describe 'alteryx-server::default' do
     end
 
     it 'Installs Alteryx Server' do
-      expect(chef_run).to install_package('Alteryx 10.6 x64')
+      expect(chef_run).to install_package('Alteryx 11.0 x64')
     end
 
     it 'Sends the install action to alteryx_server_package' do


### PR DESCRIPTION
As of 11.0, use AlteryxLicenseManager to install license files,
instead of SrcLicenseManager.