### PR TITLE
Do not call windows_package directly

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email ''
 license          'Apache 2.0'
 description      'Installs/Configures Alteryx server'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.12.2'
+version          '0.12.3'
 supports         'windows'
 source_url       'https://github.com/alteryx/cookbook-alteryx-server'
 issues_url       'https://github.com/alteryx/cookbook-alteryx-server/issues'

--- a/resources/r_package.rb
+++ b/resources/r_package.rb
@@ -26,9 +26,8 @@ action :install do
   pkg_name = "Alteryx Predictive Tools with R #{version}"
   pkg_source = source
 
-  windows_package pkg_name do
+  package pkg_name do
     source pkg_source
-    installer_type :custom
     options '/s'
     action :install
   end

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -45,7 +45,7 @@ describe 'alteryx-server::default' do
     end
 
     it 'Installs R Predictive Tools' do
-      expect(chef_run).to install_windows_package(
+      expect(chef_run).to install_package(
         'Alteryx Predictive Tools with R 3.2.3'
       )
     end


### PR DESCRIPTION
Chef has deprecated windows_package. Use the package
resource instead when running the predictive install.