### PR TITLE
Add uninstall action to  server and r_package

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -35,3 +35,7 @@ suites:
     run_list:
       - recipe[alteryx-server::default]
       - recipe[alteryx-server::license]
+  - name: uninstall
+    run_list:
+      - recipe[alteryx-server::default]
+      - recipe[alteryx-server::uninstall]

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Resources
 ---------
 
 ### alteryx_server_package
-Actions: `:install`
+Actions: `:install`, `:uninstall`
 
 Install Alteryx Server.
 
@@ -45,13 +45,21 @@ Install Alteryx Server.
 #### Examples:
 
 ```ruby
+# Install latest version of Alteryx Server
 alteryx_server_package 'Alteryx Server'
 ```
 
 ```ruby
+# Install specified version of Alteryx Server
 alteryx_server_package 'Alteryx Server' do
   source 'http://downloads.alteryx.com/Alteryx10.1.7.11834/AlteryxServerInstallx64_10.1.7.11834.exe'
   version '10.1.7.11834'
+end
+```
+```ruby
+# Uninstall Alteryx Server
+alteryx_server_package 'Alteryx Server' do
+  action :uninstall
 end
 ```
 
@@ -146,7 +154,7 @@ end
 ```
 
 ### alteryx_server_r_package
-Actions: `:install`
+Actions: `:install`, `:uninstall`
 
 Install R Predictive Tools for Alteryx Server.
 
@@ -158,13 +166,21 @@ Install R Predictive Tools for Alteryx Server.
 
 #### Examples:
 ```ruby
+# Install latest version of R Prodictive Tools
 alteryx_server_r_package 'R Predictive Tools'
 ```
 
 ```ruby
+# Install specified version of R Prodictive Tools
 alteryx_server_r_package 'R Predictive Tools' do
   source 'http://downloads.alteryx.com/Alteryx10.1.6.11313/RInstaller_10.1.6.11313.exe'
   version '3.1.3'
+end
+```
+```ruby
+# Uninstall Alteryx Server
+alteryx_server_package 'Alteryx Server' do
+  action :uninstall
 end
 ```
 

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -9,6 +9,16 @@ if defined?(ChefSpec)
       :alteryx_server_r_package, :install, resource_name)
   end
 
+  def uninstall_alteryx_server_package(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(
+      :alteryx_server_package, :uninstall, resource_name)
+  end
+
+  def uninstall_alteryx_server_r_package(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(
+      :alteryx_server_r_package, :uninstall, resource_name)
+  end
+
   def enable_alteryx_server_service(resource_name)
     ChefSpec::Matchers::ResourceMatcher.new(
       :alteryx_server_service, :enable, resource_name)

--- a/recipes/uninstall.rb
+++ b/recipes/uninstall.rb
@@ -1,0 +1,7 @@
+alteryx_server_r_package 'Alteryx Predictive Tools' do
+  action :uninstall
+end
+
+alteryx_server_package 'Alteryx Server' do
+  action :uninstall
+end

--- a/resources/package.rb
+++ b/resources/package.rb
@@ -22,3 +22,15 @@ action :install do
     action :install
   end
 end
+
+action :uninstall do
+  powershell_script 'Uninstall Alteryx' do
+    code <<-EOH
+      $product = gwmi win32_product -filter "Name LIKE 'Alteryx % x64'"
+      if ( $product ){
+        $cmd = 'C:\\ProgramData\\{0}\\AlteryxInstallx64.exe' -f $product.PackageCode
+        & $cmd /s REMOVE=TRUE MODIFY=FALSE
+      }
+      EOH
+  end
+end

--- a/resources/r_package.rb
+++ b/resources/r_package.rb
@@ -32,3 +32,16 @@ action :install do
     action :install
   end
 end
+
+action :uninstall do
+  powershell_script 'Uninstall Predictive Tools with R' do
+    code
+    <<-EOH
+      $product = gwmi win32_product -filter "Name LIKE 'Alteryx Predictive Tools with R %'"
+      if ( $product ){
+        $cmd = 'C:\\ProgramData\\{0}\\RInstaller.exe' -f $product.PackageCode
+        & $cmd /s REMOVE=TRUE MODIFY=FALSE
+      }
+      EOH
+  end
+end

--- a/spec/unit/recipes/uninstall_spec.rb
+++ b/spec/unit/recipes/uninstall_spec.rb
@@ -1,0 +1,30 @@
+#
+# Cookbook Name:: test
+# Spec:: uninstall
+#
+# Copyright (c) 2016 The Authors, All Rights Reserved.
+
+require 'spec_helper'
+
+describe 'alteryx-server::uninstall' do
+  context 'When all uninstalling packages' do
+    let(:chef_run) do
+      lwrps = %w(alteryx_server_package
+                 alteryx_server_r_package)
+      runner = ChefSpec::SoloRunner.new(
+        platform: 'windows',
+        version: '2012R2',
+        step_into: lwrps)
+      runner.converge(described_recipe)
+    end
+
+    it 'Sends the uninstall action to alteryx_server_r_package' do
+      expect(chef_run).to(
+        uninstall_alteryx_server_r_package('Alteryx Predictive Tools')
+      )
+    end
+    it 'Sends the uninstall action to alteryx_server_package' do
+      expect(chef_run).to uninstall_alteryx_server_package('Alteryx Server')
+    end
+  end
+end

--- a/test/integration/uninstall/default_spec.rb
+++ b/test/integration/uninstall/default_spec.rb
@@ -1,7 +1,7 @@
 describe package('Alteryx 11.0 x64') do
-  it { should not be_installed }
+  it { should_not be_installed }
 end
 
 describe package('Alteryx Predictive Tools with R 3.3.2') do
-  it { should not be_installed }
+  it { should_not be_installed }
 end

--- a/test/integration/uninstall/default_spec.rb
+++ b/test/integration/uninstall/default_spec.rb
@@ -1,0 +1,7 @@
+describe package('Alteryx 11.0 x64') do
+  it { should not be_installed }
+end
+
+describe package('Alteryx Predictive Tools with R 3.3.2') do
+  it { should not be_installed }
+end


### PR DESCRIPTION
This adds an uninstall action to both server and r_package.

Run: ```kitchen verify uninstall``` to have both server and R Package installed, then uninstalled.