### PR TITLE
Add timeout property to package installers

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,5 +1,6 @@
 default['alteryx'] = {}
 default['alteryx']['install_timeout'] = 3600
+default['alteryx']['r_install_timeout'] = default['alteryx']['install_timeout']
 default['alteryx']['license'] = {}
 default['alteryx']['force_secrets_update'] = nil
 default['alteryx']['r_source'] = nil

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,4 +1,5 @@
 default['alteryx'] = {}
+default['alteryx']['install_timeout'] = 3600
 default['alteryx']['license'] = {}
 default['alteryx']['force_secrets_update'] = nil
 default['alteryx']['r_source'] = nil

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email ''
 license          'Apache 2.0'
 description      'Installs/Configures Alteryx server'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.13.4'
+version          '0.13.5'
 supports         'windows'
 source_url       'https://github.com/alteryx/cookbook-alteryx-server'
 issues_url       'https://github.com/alteryx/cookbook-alteryx-server/issues'

--- a/resources/package.rb
+++ b/resources/package.rb
@@ -19,6 +19,7 @@ action :install do
     source pkg_source
     options '/s'
     version pkg_version
+    timeout node['alteryx']['install_timeout']
     action :install
   end
 end

--- a/resources/r_package.rb
+++ b/resources/r_package.rb
@@ -37,12 +37,14 @@ action :install do
       source pkg_source
       installer_type :custom
       options '/s'
+      timeout node['alteryx']['install_timeout']
       action :install
     end
   else
     package pkg_name do
       source pkg_source
       options '/s'
+      timeout node['alteryx']['install_timeout']
       action :install
     end
   end

--- a/resources/r_package.rb
+++ b/resources/r_package.rb
@@ -37,14 +37,14 @@ action :install do
       source pkg_source
       installer_type :custom
       options '/s'
-      timeout node['alteryx']['install_timeout']
+      timeout node['alteryx']['r_install_timeout']
       action :install
     end
   else
     package pkg_name do
       source pkg_source
       options '/s'
-      timeout node['alteryx']['install_timeout']
+      timeout node['alteryx']['r_install_timeout']
       action :install
     end
   end


### PR DESCRIPTION
This will allow the ability to increase the timeout when installing packages.