### PR TITLE
Pin Chef Gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 group :develop do
-  gem 'chef', '>= 12.21.14'
+  gem 'chef', '= 12.21.14'
   gem 'cookstyle', '~> 0.0.1'
   gem 'chefspec', '~> 4.7.0'
   gem 'foodcritic', '~> 6.0.0'

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 group :develop do
-  gem 'chef', '>= 12.5.1'
+  gem 'chef', '>= 12.21.14'
   gem 'cookstyle', '~> 0.0.1'
   gem 'chefspec', '~> 4.7.0'
   gem 'foodcritic', '~> 6.0.0'


### PR DESCRIPTION
The Chef Gem version 12.21.20 is broken, this pins the package to the latest 12.x release that is not broken.