### PR TITLE
Get package_name from uninstall registry entry or use generic one.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email ''
 license          'Apache 2.0'
 description      'Installs/Configures Alteryx server'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.13.6'
+version          '0.13.7'
 supports         'windows'
 source_url       'https://github.com/alteryx/cookbook-alteryx-server'
 issues_url       'https://github.com/alteryx/cookbook-alteryx-server/issues'

--- a/resources/package.rb
+++ b/resources/package.rb
@@ -4,6 +4,14 @@ property :timeout, [String, Fixnum]
 
 default_action :install
 
+def package_name
+  script = 'powershell "(Get-ItemProperty HKLM:\\\\Software\\\\Microsoft\\\\'\
+    'Windows\\\\CurrentVersion\\\\Uninstall\\\\* |  Select-Object DisplayName,'\
+    'Publisher |  Where-Object {$_.Publisher -like \'Alteryx\'}).DisplayName'
+  package_name = shell_out(script).stdout.strip
+  package_name.empty? ? 'Alteryx' : package_name
+end
+
 load_current_value do
   version node['alteryx']['version'] unless version
 
@@ -13,12 +21,12 @@ load_current_value do
 end
 
 action :install do
-  package_name = AlteryxServer::Helpers.package_name(version)
+  pkg_name = package_name
   pkg_source = source
   pkg_version = version
   pkg_timeout = timeout
 
-  package package_name do
+  package pkg_name do
     source pkg_source
     options '/s'
     version pkg_version

--- a/resources/r_package.rb
+++ b/resources/r_package.rb
@@ -12,6 +12,16 @@ def local_r_version
   shell_out(script).stdout.strip
 end
 
+# R Development Core Team
+def package_name
+  script = 'powershell "(Get-ItemProperty HKLM:\\\\Software\\\\Microsoft\\\\'\
+    'Windows\\\\CurrentVersion\\\\Uninstall\\\\* |  Select-Object DisplayName,'\
+    'Publisher |  Where-Object {$_.Publisher -like '\
+    '\'R Development Core Team\'}).DisplayName'
+  package_name = shell_out(script).stdout.strip
+  package_name.empty? ? 'AlteryxRTools' : package_name
+end
+
 load_current_value do
   r_source_attr = node['alteryx']['r_source']
   helpers = AlteryxServer::Helpers
@@ -25,7 +35,7 @@ load_current_value do
 end
 
 action :install do
-  pkg_name = "Alteryx Predictive Tools with R #{version}"
+  pkg_name = package_name
   pkg_source = source
   pkg_timeout = timeout
 

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -38,7 +38,7 @@ describe 'alteryx-server::default' do
     end
 
     it 'Installs Alteryx Server' do
-      expect(chef_run).to install_package('Alteryx 11.5 x64')
+      expect(chef_run).to install_package('Alteryx')
     end
 
     it 'Sends the install action to alteryx_server_package' do
@@ -47,7 +47,7 @@ describe 'alteryx-server::default' do
 
     it 'Installs R Predictive Tools chef-client v12' do
       expect(chef_run).to install_windows_package(
-        'Alteryx Predictive Tools with R 3.2.3'
+        'AlteryxRTools'
       )
     end
 


### PR DESCRIPTION
Due to changes made to the Windows package displayname, there was an issue of not being able to identify if a package was already installed.  This change pulls the displayname from uninstall registry entry and uses that as the package name to be installed.  This way chef is able to manage the package resources as it was intended. 